### PR TITLE
Fixed mysql connections where DB_HOST has a port number defined

### DIFF
--- a/sql-executioner.php
+++ b/sql-executioner.php
@@ -38,7 +38,13 @@ class SQL_Executioner_Plugin {
 		add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
 
 		// set up our own db connection so as to not interfer with WordPress'
-		$this->db = mysqli_connect( DB_HOST, DB_USER, DB_PASSWORD, DB_NAME );
+		$parts = explode(':', DB_HOST);
+		$host = $parts[0];
+		$port = ini_get("mysqli.default_port");
+		if ( count($parts) > 1 ) {
+			$port = $parts[1];
+		}
+		$this->db = mysqli_connect( $host, DB_USER, DB_PASSWORD, DB_NAME, $port );
 
 		// get list of tables and create dollar-sign shortcuts
 		$rst = mysqli_query( $this->db, "show tables" );


### PR DESCRIPTION
DB_HOST, defined in wp-config.php, can have a port number defined (see https://codex.wordpress.org/Editing_wp-config.php#Set_Database_Host), but mysqli_connect expects the port number as a separated parameter (see http://php.net/manual/en/mysqli.construct.php). So, if DB_HOST contains a port number, it should be passed via the 5rd parameter, not along with the $host parameter, otherwise mysql connection won't be established. This fix will break down DB_HOST and extract the port number, if necessary.